### PR TITLE
Safari fix - new URL(val, undefined) catastrophic fail

### DIFF
--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -725,7 +725,7 @@ export function createCommonJsExecuteFunction(asset: Runtime.Asset, host: Runtim
 
 function parseUrl(id: string, fromId?: string): URL {
   try {
-    const url = new URL(id, fromId);
+    const url = fromId ? new URL(id, fromId) : new URL(id);
 
     return url;
   } catch {


### PR DESCRIPTION
Hope you don't mind but I took the liberty of fixing an edge case I found on safari mobile which was causing a catastrophic failure.

Despite the fact the typings for URI(a, b) actually imply that the b property can be undefined, at runtime this gives you an exception. It looks like there are some cases where we thread through undefined (it is not supplied to the function).

The following works fine in chrome but will fail on safari:
`
new URL("memory:/compound_host_with_cache/index.js", undefined)
`

A simple null check should suffice to fix this.

Great library though, keep up the good work. I have been looking for something like this for a while now.